### PR TITLE
Increase the number of channels to export and encoding of status file

### DIFF
--- a/wayslack.py
+++ b/wayslack.py
@@ -1036,7 +1036,7 @@ class ArchiveFiles(object):
 
     def update_status(self, x):
         self.status.update(x)
-        with open_atomic(str(self.status_file)) as f:
+        with open_atomic_utf8(str(self.status_file)) as f:
             json_dump(self.status, f)
 
     def iter_file_lists(self):

--- a/wayslack.py
+++ b/wayslack.py
@@ -773,7 +773,7 @@ class BaseArchiver(object):
 
     @property
     def _list_args(self):
-        return {"types": ATTR_TO_CONVO_TYPE[self.attr]} \
+        return {"types": ATTR_TO_CONVO_TYPE[self.attr], "limit": 1000} \
                 if self.attr in ATTR_TO_CONVO_TYPE else dict()
 
     def update(self):


### PR DESCRIPTION
Pull request contains the following changes:
- increases the number of channels to export from 100 to 1000, [according to the documentation](https://api.slack.com/methods/conversations.list#arg_limit)
![image](https://user-images.githubusercontent.com/1523889/114281862-80da1c80-9a49-11eb-89a5-fd581d0a2519.png)
- uses utf8 to write status file to support non-latin characters